### PR TITLE
Feature/social login

### DIFF
--- a/src/main/java/login/tikichat/domain/user/dto/UserSocialProfileDto.java
+++ b/src/main/java/login/tikichat/domain/user/dto/UserSocialProfileDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserSignUpSocialProfileDto {
+public class UserSocialProfileDto {
 
     @Schema(description = "연동된 소셜 로그인 서비스 종류")
     @NotEmpty

--- a/src/main/java/login/tikichat/domain/user/dto/UserSocialSignUpRequest.java
+++ b/src/main/java/login/tikichat/domain/user/dto/UserSocialSignUpRequest.java
@@ -15,7 +15,7 @@ public class UserSocialSignUpRequest extends BaseUserSignUpRequest {
 
     @Schema(description = "소셜 로그인 연동 정보")
     @NotNull(message = "소셜 회원가입 시 소셜 로그인 연동 정보를 반드시 포함하여야 합니다.")
-    private UserSignUpSocialProfileDto socialProfileDto;
+    private UserSocialProfileDto socialProfileDto;
 }
 
 

--- a/src/main/java/login/tikichat/global/auth/oauth2/controller/OAuth2UserRestController.java
+++ b/src/main/java/login/tikichat/global/auth/oauth2/controller/OAuth2UserRestController.java
@@ -192,14 +192,11 @@ public class OAuth2UserRestController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
-//    /**
-//     * [테스트용 임시 메서드] 클라이언트에서 AccessToken 보내주지 않아도 테스트할 수 있도록
-//     * 백엔드에서 AccessToken 받아오는 메서드
-//     * @param registrationId
-//     * @param response
-//     * @throws IOException
-//     */
-//    @GetMapping("/api/v1/auth/social/link/{registrationId}")
+
+    /**
+     * 추후 소셜 로그인 추가 연동 시 작성
+     */
+//    @PostMapping("/api/v1/auth/social/link/{registrationId}")
 //    public ResponseEntity<Object> linkSocialProfile(@PathVariable String registrationId, @RequestParam String oauth2AccessToken, HttpServletRequest request, HttpServletResponse response) throws IOException {
 //
 //        String deviceId = jwtUtils.extractDeviceIdFromHeader(request);

--- a/src/main/java/login/tikichat/global/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/login/tikichat/global/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package login.tikichat.global.auth.oauth2.service;
 
+import login.tikichat.domain.user.dto.UserSocialProfileDto;
 import login.tikichat.domain.user.model.SocialProfile;
 import login.tikichat.domain.user.model.SocialType;
 import login.tikichat.domain.user.model.User;
@@ -177,5 +178,24 @@ public class CustomOAuth2UserService {
             return SocialType.FACEBOOK;
         }
         return SocialType.GOOGLE;
+    }
+
+
+    /**
+     * [소셜 프로필 연계 메서드]
+     * @param socialProfileDto
+     * @param user
+     */
+    @Transactional
+    public void linkSocialProfile(UserSocialProfileDto socialProfileDto, User user) {
+
+        SocialProfile socialProfile = SocialProfile.builder()
+                .socialId(socialProfileDto.getSocialId())
+                .socialEmail(socialProfileDto.getSocialEmail())
+                .socialType(socialProfileDto.getSocialType())
+                .user(user)
+                .build();
+
+        socialProfileRepository.save(socialProfile);
     }
 }

--- a/src/main/java/login/tikichat/global/response/ResultCode.java
+++ b/src/main/java/login/tikichat/global/response/ResultCode.java
@@ -20,8 +20,8 @@ public enum ResultCode {
     AUTH_CODE_SENT_SUCCESS(200, "A002", "인증 코드를 메일로 발송하였습니다."),
     EMAIL_VERIFICATION_SUCCESS(200, "A003", "이메일 인증에 성공하였습니다."),
     TOKEN_ISSUANCE_SUCCESS(200, "A004", "토큰 발급을 완료하였습니다."),
-    SOCIAL_EMAIL_NOT_REGISTERED(303, "A005", "기존에 회원으로 존재하지 않는 소셜 이메일입니다. 소셜 회원가입을 진행해 주세요."),
-    SOCIAL_PROFILE_LINKING_REQUIRED(303, "A006", "기존 계정에 소셜 계정 추가 연동이 필요합니다."),
+    SOCIAL_EMAIL_NOT_REGISTERED(400, "A005", "기존에 회원으로 존재하지 않는 소셜 이메일입니다. 소셜 회원가입을 진행해 주세요."),
+    SOCIAL_PROFILE_LINKING_REQUIRED(400, "A006", "기존 계정에 소셜 계정 추가 연동이 필요합니다."),
     SOCIAL_LOGIN_SUCCESS(200, "A007", "소셜 로그인에 성공하였습니다."),
 
     // Terms

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -5,7 +5,6 @@ spring:
         registration:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: https://${HOST}:${PORT}/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope: email, profile

--- a/src/test/java/login/tikichat/domain/user/service/SocialSignUpStrategyTest.java
+++ b/src/test/java/login/tikichat/domain/user/service/SocialSignUpStrategyTest.java
@@ -54,7 +54,7 @@ class SocialSignUpStrategyTest {
 
     UserSignUpTermsAgreementDto termsAgreementDto;
 
-    UserSignUpSocialProfileDto userSignUpSocialProfileDto;
+    UserSocialProfileDto userSocialProfileDto;
 
     UserSocialSignUpRequest userSocialSignUpRequest;
 
@@ -77,14 +77,14 @@ class SocialSignUpStrategyTest {
                 .agreements(List.of(new UserSignUpTermsAgreementDto.TermsAgreement(1L, true, "10.226.234.12", "용찬 의 iPhone 14")))
                 .build();
 
-        userSignUpSocialProfileDto = UserSignUpSocialProfileDto.builder()
+        userSocialProfileDto = UserSocialProfileDto.builder()
                 .socialId(socialId)
                 .socialEmail(socialEmail)
                 .socialType(socialType)
                 .build();
 
         userSocialSignUpRequest = UserSocialSignUpRequest.builder()
-                .socialProfileDto(userSignUpSocialProfileDto)
+                .socialProfileDto(userSocialProfileDto)
                 .email(email)
                 .nickname(nickname)
                 .termsAgreementDto(termsAgreementDto)
@@ -172,7 +172,7 @@ class SocialSignUpStrategyTest {
                 .nickname(userSocialSignUpRequest.getNickname())
                 .termsAgreementDto(userSocialSignUpRequest.getTermsAgreementDto())
                 .socialProfileDto(
-                        UserSignUpSocialProfileDto.builder()
+                        UserSocialProfileDto.builder()
                                 .socialEmail(mismatchedSocialEmail)
                                 .build())
                 .build();


### PR DESCRIPTION
1. 소셜 로그인 연동메서드는 CustomOAuth2UserService 에서 수행하도록 수정
2. 소셜 로그인 응답 HTTP Status Code 수정(네이버, 구글 소셜 로그인 오류 해결)
3. 구글 소셜 로그인 client-secret 제거(OAuth 2.0 클라이언트 타입이 Android/iOS 인 경우 client-secret 없음)