### PR TITLE
Feature/user/online

### DIFF
--- a/src/main/java/login/tikichat/domain/chatroom/dto/FindChatRoomDto.java
+++ b/src/main/java/login/tikichat/domain/chatroom/dto/FindChatRoomDto.java
@@ -65,7 +65,9 @@ public class FindChatRoomDto {
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
             Integer orderNum,
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-            Boolean isRoomClosed
+            Boolean isRoomClosed,
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+            Boolean isHostOnline
     ) {
 
     }

--- a/src/main/java/login/tikichat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/login/tikichat/domain/chatroom/service/ChatRoomService.java
@@ -13,6 +13,7 @@ import login.tikichat.domain.host.repository.HostRepository;
 import login.tikichat.domain.top_ranked_chatroom.dao.CountRankedChatRoomDao;
 import login.tikichat.domain.user.model.User;
 import login.tikichat.domain.user.repository.UserRepository;
+import login.tikichat.domain.user.service.UserStatusService;
 import login.tikichat.global.exception.BusinessException;
 import login.tikichat.global.exception.ErrorCode;
 import login.tikichat.global.exception.chatroom.ChatRoomNotFoundException;
@@ -34,6 +35,7 @@ public class ChatRoomService {
     private final HostRepository hostRepository;
     private final UserRepository userRepository;
     private final CountRankedChatRoomDao chatRoomDao;
+    private final UserStatusService userStatusService;
 
 
     @Transactional
@@ -79,7 +81,6 @@ public class ChatRoomService {
         } else {
             host = Host.builder()
                     .user(user)
-                    .isOnline(true)
                     .build();
             this.hostRepository.save(host);
         }
@@ -149,6 +150,8 @@ public class ChatRoomService {
         List<FindChatRoomDto.FindChatRoomItemRes> chatRoomItems = IntStream.range(0, chatRooms.size())
                 .mapToObj(index -> {
                     ChatRoom chatRoom = chatRooms.get(index);
+                    Boolean hostOnlineStatus = userStatusService.getUserStatus(chatRoom.getHost().getUser().getId());
+
                     return new FindChatRoomDto.FindChatRoomItemRes(
                             chatRoom.getName(),
                             chatRoom.getMaxUserCount(),
@@ -161,7 +164,8 @@ public class ChatRoomService {
                                     chatRoom.getCategory().getOrderNum()
                             ),
                             index + 1,
-                            chatRoom.isRoomClosed()
+                            chatRoom.isRoomClosed(),
+                            hostOnlineStatus
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/login/tikichat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/login/tikichat/domain/chatroom/service/ChatRoomService.java
@@ -150,14 +150,14 @@ public class ChatRoomService {
         List<FindChatRoomDto.FindChatRoomItemRes> chatRoomItems = IntStream.range(0, chatRooms.size())
                 .mapToObj(index -> {
                     ChatRoom chatRoom = chatRooms.get(index);
-                    Boolean hostOnlineStatus = userStatusService.getUserStatus(chatRoom.getHost().getUser().getId());
+                    Boolean hostOnlineStatus = userStatusService.getUserStatus(chatRoom.getHost().getUser().getId()).orElse(false);
 
                     return new FindChatRoomDto.FindChatRoomItemRes(
                             chatRoom.getName(),
                             chatRoom.getMaxUserCount(),
                             chatRoom.getCurrentUserCount(),
                             chatRoom.getTags(),
-                            chatRoom.getHost().getUser().getId(),
+                            chatRoom.getImageUrl(),
                             new FindCategoryDto.FindCategoryItemRes(
                                     chatRoom.getCategory().getCode(),
                                     chatRoom.getCategory().getName(),

--- a/src/main/java/login/tikichat/domain/host/model/Host.java
+++ b/src/main/java/login/tikichat/domain/host/model/Host.java
@@ -37,9 +37,6 @@ public class Host {
     @OneToMany(mappedBy = "host", cascade = CascadeType.ALL)
     private List<HostFollowStatus> hostFollowStatuses = new ArrayList<>();
 
-    // TODO: 실제 호스트 접속 정보 반환하도록 수정(추후)
-    private boolean isOnline;
-
     public URL getHostProfileImageUrl() {
         return user.getImageUrl();
     }
@@ -52,21 +49,13 @@ public class Host {
         return user.getDescription();
     }
 
-    public boolean isHostOnline() {
-        return isOnline;
-    }
-
-
-    public Host(
-            User user,
-            List<ChatRoom> chatRooms,
-            List<HostFollowStatus> hostFollowStatuses,
-            boolean isOnline
+    public Host(User user,
+                List<ChatRoom> chatRooms,
+                List<HostFollowStatus> hostFollowStatuses
     ) {
         this.user = user;
         this.chatRooms = chatRooms;
         this.hostFollowStatuses = hostFollowStatuses;
-        this.isOnline = isOnline;
     }
 
     // 연관관계 편의 메소드
@@ -76,16 +65,5 @@ public class Host {
             this.chatRooms.add(chatRoom);
             chatRoom.setHost(this);
         }
-    }
-
-    public Host(User user,
-                List<ChatRoom> chatRooms,
-                List<HostFollowStatus> hostFollowStatuses,
-                Boolean isOnline
-    ) {
-        this.user = user;
-        this.chatRooms = chatRooms;
-        this.hostFollowStatuses = hostFollowStatuses;
-        this.isOnline = isOnline;
     }
 }

--- a/src/main/java/login/tikichat/domain/host/repository/CustomHostFollowStatusRepository.java
+++ b/src/main/java/login/tikichat/domain/host/repository/CustomHostFollowStatusRepository.java
@@ -10,4 +10,5 @@ public interface CustomHostFollowStatusRepository {
     boolean existsByHostIdAndFollowerUserId(Long hostId, Long userId);
     List<HostFollowStatus> findByFollowerUserId(Long userId);
     List<HostFollowStatus> findByHostUserId(Long userId);
+    List<HostFollowStatus> findByFollowerId(Long followerId);
 }

--- a/src/main/java/login/tikichat/domain/host/repository/HostFollowStatusRepository.java
+++ b/src/main/java/login/tikichat/domain/host/repository/HostFollowStatusRepository.java
@@ -12,6 +12,4 @@ import java.util.Optional;
 public interface HostFollowStatusRepository extends JpaRepository<HostFollowStatus, Long>, CustomHostFollowStatusRepository {
     long countByHostId(Long hostId);
     Optional<HostFollowStatus> findByHostIdAndFollowerId(Long hostId, Long followerId);
-
-    List<HostFollowStatus> findByFollowerId(Long followerId);
 }

--- a/src/main/java/login/tikichat/domain/host/repository/impl/HostFollowStatusRepositoryImpl.java
+++ b/src/main/java/login/tikichat/domain/host/repository/impl/HostFollowStatusRepositoryImpl.java
@@ -1,8 +1,10 @@
 package login.tikichat.domain.host.repository.impl;
 
 import login.tikichat.domain.host.model.HostFollowStatus;
+import login.tikichat.domain.host.model.QHost;
 import login.tikichat.domain.host.model.QHostFollowStatus;
 import login.tikichat.domain.host.repository.CustomHostFollowStatusRepository;
+import login.tikichat.domain.user.model.QUser;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
@@ -27,9 +29,14 @@ public class HostFollowStatusRepositoryImpl extends QuerydslRepositorySupport im
     @Override
     public List<HostFollowStatus> findByFollowerUserId(Long userId) {
         final var hostFollowStatusQ = QHostFollowStatus.hostFollowStatus;
+        final var hostQ = QHost.host;
+        final var userQ = QUser.user;
         final var query = super.from(hostFollowStatusQ);
 
-        return query.where(hostFollowStatusQ.follower.user.id.eq(userId))
+        return query
+                .join(hostFollowStatusQ.host, hostQ).fetchJoin()
+                .join(hostQ.user, userQ).fetchJoin()
+                .where(hostFollowStatusQ.follower.user.id.eq(userId))
                 .fetch();
     }
 
@@ -39,6 +46,20 @@ public class HostFollowStatusRepositoryImpl extends QuerydslRepositorySupport im
         final var query = super.from(hostFollowStatusQ);
 
         return query.where(hostFollowStatusQ.host.user.id.eq(userId))
+                .fetch();
+    }
+
+    @Override
+    public List<HostFollowStatus> findByFollowerId(Long followerId) {
+        final var hostFollowStatusQ = QHostFollowStatus.hostFollowStatus;
+        final var hostQ = QHost.host;
+        final var userQ = QUser.user;
+        final var query = super.from(hostFollowStatusQ);
+
+        return query
+                .join(hostFollowStatusQ.host, hostQ).fetchJoin()
+                .join(hostQ.user, userQ).fetchJoin()
+                .where(hostFollowStatusQ.follower.id.eq(followerId))
                 .fetch();
     }
 }

--- a/src/main/java/login/tikichat/domain/host/service/HostService.java
+++ b/src/main/java/login/tikichat/domain/host/service/HostService.java
@@ -14,6 +14,7 @@ import login.tikichat.domain.host.repository.HostRepository;
 import login.tikichat.domain.host.repository.HostFollowStatusRepository;
 import login.tikichat.domain.user.model.User;
 import login.tikichat.domain.user.repository.UserRepository;
+import login.tikichat.domain.user.service.UserStatusService;
 import login.tikichat.global.exception.BusinessException;
 import login.tikichat.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ public class HostService {
     private final HostRepository hostRepository;
     private final FollowerRepository followerRepository;
     private final UserRepository userRepository;
+    private final UserStatusService userStatusService;
 
     @Transactional
     public HostFollowDto.HostFollowRes follow(Long hostId, Long userId) {
@@ -97,7 +99,7 @@ public class HostService {
                         .hostId(host.getId())
                         .hostNickname(host.getHostNickname())
                         .hostProfileImageUrl(host.getHostProfileImageUrl())
-                        .isOnline(host.isHostOnline())
+                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()))
                         .build())
                 .toList();
 
@@ -112,7 +114,7 @@ public class HostService {
                         .hostId(host.getId())
                         .hostNickname(host.getHostNickname())
                         .hostProfileImageUrl(host.getHostProfileImageUrl())
-                        .isOnline(host.isHostOnline())
+                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()))
                         .build())
                 .toList();
 

--- a/src/main/java/login/tikichat/domain/host/service/HostService.java
+++ b/src/main/java/login/tikichat/domain/host/service/HostService.java
@@ -99,7 +99,7 @@ public class HostService {
                         .hostId(host.getId())
                         .hostNickname(host.getHostNickname())
                         .hostProfileImageUrl(host.getHostProfileImageUrl())
-                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()))
+                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()).orElse(false))
                         .build())
                 .toList();
 
@@ -114,7 +114,7 @@ public class HostService {
                         .hostId(host.getId())
                         .hostNickname(host.getHostNickname())
                         .hostProfileImageUrl(host.getHostProfileImageUrl())
-                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()))
+                        .isOnline(userStatusService.getUserStatus(host.getUser().getId()).orElse(false))
                         .build())
                 .toList();
 
@@ -149,19 +149,22 @@ public class HostService {
         List<FindChatRoomDto.FindChatRoomItemRes> chatRoomResponses = IntStream.range(0, chatRooms.size())
                 .mapToObj(index -> {
                     ChatRoom chatRoom = chatRooms.get(index);
+                    Boolean hostOnlineStatus = userStatusService.getUserStatus(chatRoom.getHost().getUser().getId()).orElse(false);
+
                     return FindChatRoomDto.FindChatRoomItemRes.builder()
-                            .hostId(chatRoom.getHost().getUser().getId())
                             .name(chatRoom.getName())
+                            .maxUserCount(chatRoom.getMaxUserCount())
                             .currentUserCount(chatRoom.getCurrentUserCount())
+                            .tags(chatRoom.getTags())
+                            .chatRoomImageUrl(chatRoom.getImageUrl())
                             .category(new FindCategoryDto.FindCategoryItemRes(
                                     chatRoom.getCategory().getCode(),
                                     chatRoom.getCategory().getName(),
                                     chatRoom.getCategory().getOrderNum()
                             ))
-                            .maxUserCount(chatRoom.getMaxUserCount())
-                            .tags(chatRoom.getTags())
                             .orderNum(index)
                             .isRoomClosed(chatRoom.isRoomClosed())
+                            .isHostOnline(hostOnlineStatus)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/login/tikichat/domain/user/controller/UserRestController.java
+++ b/src/main/java/login/tikichat/domain/user/controller/UserRestController.java
@@ -220,7 +220,7 @@ public class UserRestController {
             @ApiResponse(responseCode = "404", description = "가입된 계정을 찾을 수 없습니다.")
     })
     public ResponseEntity<ResultResponse> findUserStatus(@RequestParam Long userId) {
-        Boolean userStatus = userStatusService.getUserStatus(userId);
+        Boolean userStatus = userStatusService.getUserStatus(userId).orElse(false);
         ResultResponse result = ResultResponse.of(ResultCode.FIND_USER_STATUS_SUCCESS, userStatus);
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }

--- a/src/main/java/login/tikichat/domain/user/controller/UserRestController.java
+++ b/src/main/java/login/tikichat/domain/user/controller/UserRestController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import login.tikichat.domain.user.dto.*;
 import login.tikichat.domain.user.service.UserService;
+import login.tikichat.domain.user.service.UserStatusService;
 import login.tikichat.global.auth.UserDetailInfo;
 import login.tikichat.global.auth.verification.service.AuthService;
 import login.tikichat.global.exception.user.NicknameAlreadyInUseException;
@@ -38,6 +39,7 @@ import java.net.URL;
 public class UserRestController {
 
     private final UserService userService;
+    private final UserStatusService userStatusService;
     private final AuthService authService;
 
     @GetMapping("/search")
@@ -208,6 +210,18 @@ public class UserRestController {
         URL imageUrl = userService.setUserProfileImage(email, user, profileImageFile);
 
         ResultResponse result = ResultResponse.of(ResultCode.PROFILE_IMAGE_SET_SUCCESS, imageUrl);
+        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+    }
+
+    @GetMapping("/{userId}/status")
+    @Operation(summary = "회원 On/Offline 상태 조회", description = "회원 On/Offline 상태를 조회하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 On/Offline 상태 조회에 성공하였습니다."),
+            @ApiResponse(responseCode = "404", description = "가입된 계정을 찾을 수 없습니다.")
+    })
+    public ResponseEntity<ResultResponse> findUserStatus(@RequestParam Long userId) {
+        Boolean userStatus = userStatusService.getUserStatus(userId);
+        ResultResponse result = ResultResponse.of(ResultCode.FIND_USER_STATUS_SUCCESS, userStatus);
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 }

--- a/src/main/java/login/tikichat/domain/user/service/UserStatusService.java
+++ b/src/main/java/login/tikichat/domain/user/service/UserStatusService.java
@@ -1,0 +1,23 @@
+package login.tikichat.domain.user.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserStatusService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final static String USER_STATUS_KEY_PREFIX = "user:status:";
+
+    public UserStatusService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setUserStatus(Long userId, boolean isOnline) {
+        redisTemplate.opsForValue().setBit(USER_STATUS_KEY_PREFIX, userId, isOnline);
+    }
+
+    public Boolean getUserStatus(Long userId) {
+        return redisTemplate.opsForValue().getBit(USER_STATUS_KEY_PREFIX, userId);
+    }
+}

--- a/src/main/java/login/tikichat/domain/user/service/UserStatusService.java
+++ b/src/main/java/login/tikichat/domain/user/service/UserStatusService.java
@@ -3,21 +3,30 @@ package login.tikichat.domain.user.service;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.util.Optional;
+
 @Service
 public class UserStatusService {
 
     private final StringRedisTemplate redisTemplate;
-    private final static String USER_STATUS_KEY_PREFIX = "user:status:";
+
+    private static final String USER_STATUS_KEY_PREFIX = "user:";
+    private static final String USER_STATUS_KEY_SUFFIX = ":status";
+    private static final long STATUS_TTL_MINUTES = 3;
 
     public UserStatusService(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
     public void setUserStatus(Long userId, boolean isOnline) {
-        redisTemplate.opsForValue().setBit(USER_STATUS_KEY_PREFIX, userId, isOnline);
+        String key = USER_STATUS_KEY_PREFIX + userId + USER_STATUS_KEY_SUFFIX;
+        redisTemplate.opsForValue().set(key, String.valueOf(isOnline), Duration.ofMinutes(STATUS_TTL_MINUTES));
     }
 
-    public Boolean getUserStatus(Long userId) {
-        return redisTemplate.opsForValue().getBit(USER_STATUS_KEY_PREFIX, userId);
+    public Optional<Boolean> getUserStatus(Long userId) {
+        String key = USER_STATUS_KEY_PREFIX + userId + USER_STATUS_KEY_SUFFIX;
+        String userStatus = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(userStatus).map(Boolean::valueOf);
     }
 }

--- a/src/main/java/login/tikichat/global/config/RedisConfig.java
+++ b/src/main/java/login/tikichat/global/config/RedisConfig.java
@@ -9,6 +9,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 public class RedisConfig {
@@ -26,6 +28,7 @@ public class RedisConfig {
     public StringRedisTemplate redisTemplate(RedisConnectionFactory redisMailConnectionFactory) {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(redisMailConnectionFactory);
+        stringRedisTemplate.setEnableTransactionSupport(true);
         return stringRedisTemplate;
     }
 
@@ -37,5 +40,10 @@ public class RedisConfig {
     @Bean
     public ChannelTopic chatReactionChannelTopic() {
         return new ChannelTopic("chat_reaction");
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
     }
 }

--- a/src/main/java/login/tikichat/global/listener/WebSocketEventListener.java
+++ b/src/main/java/login/tikichat/global/listener/WebSocketEventListener.java
@@ -1,0 +1,65 @@
+package login.tikichat.global.listener;
+
+import login.tikichat.domain.user.service.UserStatusService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+    private final UserStatusService userStatusService;
+    private final StringRedisTemplate redisTemplate;
+
+    @EventListener
+    @Transactional
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String userIdHeader = headerAccessor.getFirstNativeHeader("userId");
+        String sessionId = headerAccessor.getSessionId();
+
+        if (userIdHeader == null || sessionId == null) {
+            log.error("Invalid WebSocket connection: missing userId or sessionId");
+            throw new IllegalArgumentException("Invalid connection: userId or sessionId is missing");
+        }
+
+        Long userId = Long.valueOf(userIdHeader);
+
+        if (redisTemplate.opsForValue().get(sessionId) == null) {
+            userStatusService.setUserStatus(userId, true);
+            redisTemplate.opsForValue().set(sessionId, userIdHeader);
+            log.info("User with ID {} connected with session {}", userId, sessionId);
+        } else {
+            log.warn("Session {} is already associated with a user", sessionId);
+        }
+    }
+
+    @EventListener
+    @Transactional
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+
+        if (sessionId == null) {
+            log.error("Invalid WebSocket disconnection: missing sessionId");
+            return;
+        }
+
+        String userIdStr = redisTemplate.opsForValue().getAndDelete(sessionId);
+        if (userIdStr != null) {
+            Long userId = Long.valueOf(userIdStr);
+            userStatusService.setUserStatus(userId, false);
+            log.info("User with ID {} disconnected with session {}", userId, sessionId);
+        } else {
+            log.warn("No associated user found for session {}", sessionId);
+        }
+    }
+}

--- a/src/main/java/login/tikichat/global/response/ResultCode.java
+++ b/src/main/java/login/tikichat/global/response/ResultCode.java
@@ -16,6 +16,7 @@ public enum ResultCode {
     LOGIN_SUCCESS(200, "U006", "로그인에 성공하였습니다."),
     NICKNAME_SET_SUCCESS(200, "U007", "닉네임 설정을 완료하였습니다."),
     PROFILE_IMAGE_SET_SUCCESS(200, "U008", "프로필 사진 설정을 완료하였습니다."),
+    FIND_USER_STATUS_SUCCESS(200, "U009", "회원 On/Offline 상태 조회에 성공하였습니다."),
 
     // Auth
     PASSWORD_SET_SUCCESS(200, "A001", "비밀번호 설정을 완료하였습니다."),


### PR DESCRIPTION
■ 주요 사항
1. SessionConnectedEvent, SessionDisconnectEvent 를 처리하는 EventListener 추가
2. SessionConnectedEvent 발생 시, 아래 작업 수행
  2-1. header로 넘어온 userId 를 받아서 Redis 에 저장 (key : sessionId / value : userId)
  2-2. Redis 비트맵 자료구조로 userId 에 해당하는 비트 1로 켬 (메모리 최적화 목적으로 비트맵 사용했습니다)
3. SessionDisconnectEvent 발생 시, 아래 작업 수행
  3-1. 연결이 끊긴 웹소켓의 sessionId 로 Redis 에 저장된 userId 조회
  3-2. Redis 비트맵 자료구조로 userId 에 해당하는 비트 0으로 끔
4. UserStatusService 의 getUserStatus(Long userId) 메서드 호출 시, userId 에 해당하는 비트 값(1이면 Online, 0이면 Offline) 조회해서 리턴

※ 추가로, QueryDsl 코드 부분 ChatRoom 조회할 때, ChatRoom.Host 랑 ChatRoom.Host.User 엔티티 fetch join 하도록 변경했습니다. 현재 저희 앱 화면 설계상 ChatRoom Response 로 응답하는 부분에는 예외없이 ChatRoom Host On/Offline 상태가 함께 나타나게끔 되어 있어서, Lazy Loading 으로 네트워크 IO 여러번 발생하는 것보다 한 번에 조회해서 가져오는 게 조금이나마 빠를 것 같아서요!